### PR TITLE
fix require lib name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spammer-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "server.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const {
 } = require('microrouter')
 
 const readdirPromise = promisify(readdir)
-const Spammer = require('./lib/Spammer')
+const Spammer = require('./lib/spammer')
 const spammer = new Spammer()
 
 const spam = async (req, res) => {


### PR DESCRIPTION
fix caps on require lib name.
when running with [spammer-runner](https://github.com/blackcapz/spammer-runner), the docker container could not find the module
